### PR TITLE
Feature/driftdetection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,15 @@
 version: 2.1
+
+notify:
+  webhooks:
+    - url: https://outlook.office.com/webhook/f56ae5c1-eecf-43ad-83c1-bb0d73bd13b5@5e0b361b-59ed-466e-8759-030448046197/CircleCI/b38cbeb3699648389914128950826ddc/3ead529e-38c0-45d8-b1d5-2126df5677b0
+
+experimental:
+  notify:
+    branches:
+      only:
+        - master
+
 # Jobs must be added to the workflow at the bottom to be run
 jobs:
   # Installs and runs repo-supervisor
@@ -92,7 +103,7 @@ workflows:
     driftdetect:
         triggers:
           - schedule:
-              cron: "0,5,10,15,20,25,30,35,40,45,50,55 * * * *"
+              cron: "40 21 * * *"
               filters:
                 branches:
                   only:
@@ -100,7 +111,6 @@ workflows:
         jobs:
             - detectdrift:
                 context: dateline-lambda
-                # Only run this job on the master branch
                 filters:
                   branches:
                      only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ workflows:
         triggers:
           - schedule:
               # scheduled for 2pm UTC or 8am MT
-              cron: "0 14 * * *"
+              cron: "23 1 * * *" #"0 14 * * *"
               filters:
                 branches:
                   only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,13 @@ jobs:
       - checkout
       - run: terraform init
       - run: terraform apply -auto-approve
+  detectdrift:
+    docker:
+      - image: hashicorp/terraform:0.12.1
+    steps:
+      - checkout
+      - run: terraform init
+      - run: terraform plan -detailed-exitcode 
 
 workflows:
     flow:
@@ -78,6 +85,18 @@ workflows:
                   branches:
                      only:
                        - master
+                       - feature/driftdetection
+                # Don't run if the repo-supervisor or terrascan jobs fail
+                requires:
+                  - repo-supervisor
+                  #- terrascan
+            - detectdrift:
+                context: dateline-lambda
+                # Only run this job on the master branch
+                filters:
+                  branches:
+                     only:
+                       - feature/driftdetection
                 # Don't run if the repo-supervisor or terrascan jobs fail
                 requires:
                   - repo-supervisor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ workflows:
     driftdetect:
         triggers:
           - schedule:
-              cron: "40 21 * * *"
+              cron: "42 0 * * *"
               filters:
                 branches:
                   only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ workflows:
     driftdetect:
         triggers:
           - schedule:
-              cron: "48 0 * * *"
+              cron: "8 1 * * *"
               filters:
                 branches:
                   only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,15 +93,12 @@ workflows:
     driftdetect:
         triggers:
           - schedule:
-              cron: "8 1 * * *"
+              # scheduled for 2pm UTC or 8am MT
+              cron: "0 14 * * *"
               filters:
                 branches:
                   only:
-                    - feature/driftdetection
+                    - master
         jobs:
             - detectdrift:
                 context: dateline-lambda
-                filters:
-                  branches:
-                     only:
-                       - feature/driftdetection

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,5 @@
 version: 2.1
 
-notify:
-  webhooks:
-    - url: https://outlook.office.com/webhook/f56ae5c1-eecf-43ad-83c1-bb0d73bd13b5@5e0b361b-59ed-466e-8759-030448046197/CircleCI/b38cbeb3699648389914128950826ddc/3ead529e-38c0-45d8-b1d5-2126df5677b0
-
-experimental:
-  notify:
-    branches:
-      only:
-        - master
-
 # Jobs must be added to the workflow at the bottom to be run
 jobs:
   # Installs and runs repo-supervisor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,11 +94,11 @@ workflows:
         triggers:
           - schedule:
               # scheduled for 2pm UTC or 8am MT
-              cron: "23 1 * * *" #"0 14 * * *"
+              cron: "26 1 * * *" #"0 14 * * *"
               filters:
                 branches:
                   only:
-                    - master
+                    - feature/driftdetect
         jobs:
             - detectdrift:
                 context: dateline-lambda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,11 +94,11 @@ workflows:
         triggers:
           - schedule:
               # scheduled for 2pm UTC or 8am MT
-              cron: "26 1 * * *" #"0 14 * * *"
+              cron: "28 1 * * *" #"0 14 * * *"
               filters:
                 branches:
                   only:
-                    - feature/driftdetect
+                    - feature/driftdetection
         jobs:
             - detectdrift:
                 context: dateline-lambda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,15 @@ workflows:
                 requires:
                   - repo-supervisor
                   #- terrascan
+    driftdetect:
+        triggers:
+          - schedule:
+              cron: "*/5 * * * *"
+              filters:
+                branches:
+                  only:
+                    - feature/implement
+        jobs:
             - detectdrift:
                 context: dateline-lambda
                 # Only run this job on the master branch
@@ -96,7 +105,3 @@ workflows:
                   branches:
                      only:
                        - feature/driftdetection
-                # Don't run if the repo-supervisor or terrascan jobs fail
-                requires:
-                  - repo-supervisor
-                  #- terrascan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,11 +103,11 @@ workflows:
     driftdetect:
         triggers:
           - schedule:
-              cron: "42 0 * * *"
+              cron: "48 0 * * *"
               filters:
                 branches:
                   only:
-                    - feature/implement
+                    - feature/driftdetection
         jobs:
             - detectdrift:
                 context: dateline-lambda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ workflows:
                   branches:
                      only:
                        - master
-                       - feature/driftdetection
                 # Don't run if the repo-supervisor or terrascan jobs fail
                 requires:
                   - repo-supervisor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
     driftdetect:
         triggers:
           - schedule:
-              cron: "*/5 * * * *"
+              cron: "0,5,10,15,20,25,30,35,40,45,50,55 * * * *"
               filters:
                 branches:
                   only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,11 +94,11 @@ workflows:
         triggers:
           - schedule:
               # scheduled for 2pm UTC or 8am MT
-              cron: "28 1 * * *" #"0 14 * * *"
+              cron: "0 14 * * *"
               filters:
                 branches:
                   only:
-                    - feature/driftdetection
+                    - master
         jobs:
             - detectdrift:
                 context: dateline-lambda


### PR DESCRIPTION
Implemented a scheduled CircleCI workflow to run `terraform plan -detailed-exitcode` to detect if there is drift between the terraform state the real environment.

Runs on the master branch
Fails if there are any changes
Scheduled daily for 2pm UTC or 8am MT